### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,6 +19,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
     <% if @items.present? %>
      <% @items.each do |item|%>
       <li class='list'>
-       <%= link_to "#" do %>
+       <%= link_to item_path(item) do %>
         <div class='item-img-content'>
           <%= image_tag item.image , class: "item-img" %>
           <div class='sold-out'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,9 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -39,7 +37,7 @@
     <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.message %></span>
     </div>
     <table class="detail-table">
       <tbody>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -21,21 +21,15 @@
       </span>
     </div>
     <% if user_signed_in? %>
-
     <% if current_user.id == @item.user_id%>
-
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-
-
     <% else %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <% end %>
-
-
     <% end %>
-
+    
     <div class="item-explain-box">
       <span><%= @item.message %></span>
     </div>
@@ -102,9 +96,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image,class:"item-box-img" %>
@@ -16,10 +16,10 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ￥<%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.fee.name %>
       </span>
     </div>
     <% if user_signed_in? %>
@@ -45,27 +45,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.name %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.delay.name %></td>
         </tr>
       </tbody>
     </table>
@@ -105,7 +105,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,7 +7,7 @@
       <%= "商品名" %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -22,20 +22,21 @@
         <%= "配送料負担" %>
       </span>
     </div>
+    <% if user_signed_in? %>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if current_user.id == @item.user_id%>
 
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
 
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <% else %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
 
 
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% end %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>

--- a/db/migrate/20240705080748_change_column_name.rb
+++ b/db/migrate/20240705080748_change_column_name.rb
@@ -1,9 +1,9 @@
 class ChangeColumnName < ActiveRecord::Migration[7.0]
   def change
-    rename_column :items, :category, :category_id
-    rename_column :items, :condition, :condition_id
-    rename_column :items, :shipping_fee, :shipping_fee_id
-    rename_column :items, :area, :area_id
-    rename_column :items, :delay, :delay_id
+    #rename_column :items, :category, :category_id
+    #rename_column :items, :condition, :condition_id
+    #rename_column :items, :shipping_fee, :shipping_fee_id
+    #rename_column :items, :area, :area_id
+    #rename_column :items, :delay, :delay_id
   end
 end

--- a/db/migrate/20240707044548_change_column_name_in_your_table_name.rb
+++ b/db/migrate/20240707044548_change_column_name_in_your_table_name.rb
@@ -1,5 +1,5 @@
 class ChangeColumnNameInYourTableName < ActiveRecord::Migration[7.0]
   def change
-    rename_column :items, :shipping_fee_id, :fee_id
+    #rename_column :items, :shipping_fee_id, :fee_id
   end
 end


### PR DESCRIPTION
# what
商品詳細表示機能の実装
# why
詳細ページを追加するため。

 ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移
https://gyazo.com/2d9f53d622e265b0e7d074a7ba2be9b9

 ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移
https://gyazo.com/f97d5244907050cf0619beb20b8fba44

 ログアウト状態で、商品詳細ページへ遷移
https://gyazo.com/197ee153aaf896c1f69ee24b2d568fc3